### PR TITLE
Fix spooler jobs in stats

### DIFF
--- a/django_uwsgi/stats.py
+++ b/django_uwsgi/stats.py
@@ -13,7 +13,7 @@ def get_uwsgi_stats():
         w['running_time'] = w['running_time'] / 1000
         w['load'] = w['running_time'] / total_load / 10 / len(workers)
         w['last_spawn'] = datetime.fromtimestamp(w['last_spawn'])
-    jobs = {}
+    jobs = []
     if uwsgi.opt['spooler']:
         spooler_jobs = uwsgi.spooler_jobs()
         for j in spooler_jobs:


### PR DESCRIPTION
While collecting stats, spooler jobs var is initialized as an empty dict.
When there are pending jobs, they are appended to the dict, raising an Exception.
Changing it to a list solves the issue, at least in admin view.