### PR TITLE
Resolve compatibility issue

### DIFF
--- a/django_uwsgi/urls.py
+++ b/django_uwsgi/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from . import views
 
 urlpatterns = [

--- a/django_uwsgi/urls.py
+++ b/django_uwsgi/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import patterns, url
 from . import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.UwsgiStatus.as_view(), name='uwsgi_index'),
     url(r'^reload/$', views.UwsgiReload.as_view(), name='uwsgi_reload'),
     url(r'^clear_cache/$', views.UwsgiCacheClear.as_view(), name='uwsgi_cache_clear'),
-)
+]


### PR DESCRIPTION
django.conf.urls.patterns() is deprecated and will be removed in Django 1.10

https://docs.djangoproject.com/es/1.9/ref/urls/#django.conf.urls.patterns