### PR TITLE
Include documentation and assets in source tarballs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include CONTRIBUTORS LICENSE *.rst
 recursive-include django_uwsgi *
+recursive-include docs Makefile conf.py requirements-docs.txt *.rst *.png
 recursive-exclude * __pycache__
 recursive-exclude * *.py[cod]


### PR DESCRIPTION
This would allow to build the documenation in distribution packages like the one
I maintain for Debian.