### PR TITLE
Only include assets not handled by setup.py in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include CONTRIBUTORS LICENSE *.rst
-recursive-include django_uwsgi *
+recursive-include django_uwsgi *.html
 recursive-include docs Makefile conf.py requirements-docs.txt *.rst *.png
 recursive-exclude * __pycache__
 recursive-exclude * *.py[cod]


### PR DESCRIPTION
Otherwise files like .DS_Store are also accidentially included in the source
tarball.
