### PR TITLE
Support UWSGI options in settings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Alan Justino da Silva, alanjds, <alan.justino@yahoo.com.br>
 Michael Fladischer, fladi, <michael@fladi.at>
 Paul Bailey, pizzapanther
 Arkadiusz Adamski, ar4s
+Dominik George, Natureshadow, <nik@naturalnet.de>

--- a/django_uwsgi/management/commands/runuwsgi.py
+++ b/django_uwsgi/management/commands/runuwsgi.py
@@ -25,6 +25,13 @@ class Command(BaseCommand):
                 self.http_port = None
                 self.socket_addr = v
 
+        # Preload options from settings
+        for option, value in getattr(settings, "UWSGI", {}):
+            envvar = option.upper().replace("-", "_")
+            if isinstance(value, bool):
+                value = "true" if value else "false"
+            os.environ.setdefault("UWSGI_%s" % envvar, str(value))
+
         # load the Django WSGI handler
         os.environ.setdefault('UWSGI_MODULE', '%s.wsgi' % django_project)
         # DJANGO settings

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -31,3 +31,13 @@ Other options
 
 Any other options can be passed via environment variables, prefixed with `UWSGI_` and converted
 to upper-case, or as key-value pairs in a dictionary named `UWSGI` in settings.
+
+Options from `UWSGI` in settings are passed to uwsgi as INI, which allows passing multi-value
+options. Example:
+
+.. code-block:: python
+
+   UWSGI = {
+       "module": "my.project.wsgi",
+       "attach-daemon": ["memcached -p 11311", "celery -A my.project.tasks worker"]
+   }

--- a/docs/command.rst
+++ b/docs/command.rst
@@ -12,7 +12,7 @@ runuwsgi options:
 -----------------
 
 http
----- 
+----
 
 .. code-block:: sh
 
@@ -29,4 +29,5 @@ socket
 Other options
 -------------
 
-Any other options can be passed via environment variables, prefixed with `UWSGI_`
+Any other options can be passed via environment variables, prefixed with `UWSGI_` and converted
+to upper-case, or as key-value pairs in a dictionary named `UWSGI` in settings.


### PR DESCRIPTION
This change allows options to be specified in a dictionary in the project settings, like so:

```python
UWSGI = {
    "module": "aleksis.core.wsgi",
    "log-master": "true",
}
```

They are converted to uWSGI's custom INI format and streamd through a pipe, which allows passing multi-value options like `attach-daemon`. I would have liked to use JSON or YAML for that, but JSON is not enabled in uWSGI's default profile, and the default YAML parser in uWSGI is so flaky that I didn't get it to reliably parse valid YAML. I finally decided to go for the INI approach, although it might be broken by invalid input. I tried to prevent the worst by not allowing line breaks in values, because that would allow to inject "hidden" lines.