### PR TITLE
Django 4.x support

### DIFF
--- a/django_uwsgi/emperor/admin.py
+++ b/django_uwsgi/emperor/admin.py
@@ -1,5 +1,8 @@
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
 from .models import Vassal
 
 

--- a/django_uwsgi/emperor/models.py
+++ b/django_uwsgi/emperor/models.py
@@ -1,6 +1,9 @@
 import time
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
 from django.utils.text import get_valid_filename, slugify
 from django.utils.encoding import python_2_unicode_compatible
 

--- a/django_uwsgi/panels.py
+++ b/django_uwsgi/panels.py
@@ -1,5 +1,8 @@
 from debug_toolbar.panels import Panel
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
 from . import uwsgi
 
 

--- a/django_uwsgi/stats.py
+++ b/django_uwsgi/stats.py
@@ -1,7 +1,10 @@
 import os
 import time
 from datetime import datetime
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
 from . import uwsgi
 
 

--- a/django_uwsgi/urls.py
+++ b/django_uwsgi/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
 from django.contrib import admin
 from . import views
 

--- a/django_uwsgi/views.py
+++ b/django_uwsgi/views.py
@@ -1,6 +1,10 @@
 from __future__ import unicode_literals
 from django.http import HttpResponseRedirect
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
+
 from django.contrib import messages
 try:
     from django.urls import reverse_lazy

--- a/django_uwsgi/wagtail_hooks.py
+++ b/django_uwsgi/wagtail_hooks.py
@@ -1,4 +1,7 @@
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import ngettext_lazy as _
 
 from . import uwsgi, urls
 from .compat import include, url, reverse_lazy


### PR DESCRIPTION
Django 4.x has some changes that brake the django-uwsgi library.

Mainly:
- django.utils.translation.ugettext_lazy
- from django.conf.urls.url

Which now are respectively:
- from django.utils.translation.ngettext_lazy
- from django.urls.re_path